### PR TITLE
チェックツールページを封鎖

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,7 +171,7 @@ nav:
     - HEOExporter Tutorial : WorldMakingGuide/HEOExporter_Tutorial.md
     - Debug Console: debugconsole/debugconsole.md
     - Debug Messages: debugconsole/debugmessage.md
-    - Check Tool: checktool/checktool.md
+    #- Check Tool: checktool/checktool.md #デバッグコンソール新設に伴い廃止。アーカイブのためファイルは残す
     - Auto Texture Compression: AutoTextureCompresser/AutoTextureCompresser.md
     - Texture Compression : heoexporter/he_TextureCompression.md
     - Particle Editor :


### PR DESCRIPTION
チェックツールの廃止に伴い、ページへの封鎖を行いました。
アーカイブ性の観点からファイルの削除は見送っておりますが、問題があれば削除対応をかけます。