### PR TITLE
チェンジログのリンクを絶対パスに変更

### DIFF
--- a/docs/changelog/changelog-5.4.en.md
+++ b/docs/changelog/changelog-5.4.en.md
@@ -1,45 +1,45 @@
 # Added Pages
-- [HEOSpot](../HEOComponents/HEOSpot.md)
-- [HEOSpawn](../HEOComponents/HEOSpawn.md)
+- [HEOSpot](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/HEOComponents/HEOSpot.html)
+- [HEOSpawn](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/HEOComponents/HEOSpawn.html)
 - [HEOShadow](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/HEOComponents/HEOShadow.html)
-- [HEOClickGuide](../HEOComponents/HEOClickGuide.md)
-- [SDK does not appear after install](../troubleshooting/InstallingDeeplink.md)
-- [Debug Console](../debugconsole/debugconsole.md)
-- [Debug Message](../debugconsole/debugmessage.md)
-- [Browser window blackouts](../troubleshooting/BrowserBlackWindow.md)
-- [How to Animate an Object](../WorldMakingGuide/PropAnimation.md) *English Version WIP
-- [How to Animate an Object - TroubleShooting](../WorldMakingGuide/PropAnimation_TroubleShooting.md) *English Version WIP
-- [Missing Components After Version Update](../troubleshooting/MissingComponents.md)
-- [Adding Preset Avatars](../WorldMakingGuide/PresetAvatar.md)
+- [HEOClickGuide](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/HEOComponents/HEOClickGuide.html)
+- [SDK does not appear after install](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/troubleshooting/InstallingDeeplink.html)
+- [Debug Console](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/debugconsole/debugconsole.html)
+- [Debug Message](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/debugconsole/debugmessage.html)
+- [Browser window blackouts](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/troubleshooting/BrowserBlackWindow.html)
+- [How to Animate an Object](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/WorldMakingGuide/PropAnimation.html) *English Version WIP
+- [How to Animate an Object - TroubleShooting](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/WorldMakingGuide/PropAnimation_TroubleShooting.html) *English Version WIP
+- [Missing Components After Version Update](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/troubleshooting/MissingComponents.html)
+- [Adding Preset Avatars](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/WorldMakingGuide/PresetAvatar.html)
 
 # Edited Pages
-- [Overview](../index.md)
-    - Added information about [Release Note](../releasenote/releasenote-5.4.md) and [Change Log](../changelog/changelog-5.4.md)
-- [How to install VketCloud SDK](../AboutVketCloudSDK/SetupSDK_external.md)
+- [Overview](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/index.html)
+    - Added information about [Release Note](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/releasenote/releasenote-5.4.html) and [Change Log](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/changelog/changelog-5.4.html)
+- [How to install VketCloud SDK](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/AboutVketCloudSDK/SetupSDK_external.html)
     - Added solution when required packages does not become installed automatically
     - Instructions on how to switch SDK versions
-- [How to use avatars](../AboutVketCloudSDK/SetupAvatar.md)
+- [How to use avatars](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/AboutVketCloudSDK/SetupAvatar.html)
     - Updated instructions on adding avatars
-- [Texture Compression](../heoexporter/he_TextureCompression.md)
+- [Texture Compression](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/heoexporter/he_TextureCompression.html)
     - Updated instructions according to Ver5.4
-- [HEOVideoTrigger](../HEOComponents/HEOVideoTrigger.md)
+- [HEOVideoTrigger](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/HEOComponents/HEOVideoTrigger.html)
     - Updated discription according to Ver5.4
     - Added explanation of audio distance falloff unsupported
-- [HEOWorldSetting](../HEOComponents/HEOWorldSetting.md)
+- [HEOWorldSetting](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/HEOComponents/HEOWorldSetting.html)
     - Updated discription according to Ver5.4 
     - Added explanation of gamepad / emote related issues 
     - Added restriction on using lights
     - Added how to create dynamic shadows using [HEOShadow](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/HEOComponents/HEOShadow.html)
-- [HEOAnimation](../HEOComponents/HEOAnimation.md)
+- [HEOAnimation](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/HEOComponents/HEOAnimation.html)
     - Added how to use for HEOAnimation
-- [HEOAudio](../HEOComponents/HEOAudio.md)
+- [HEOAudio](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/HEOComponents/HEOAudio.html)
     - Added discription according to Ver5.4
-- [Specification Limit of Vket Cloud](../WorldMakingGuide/UnityGuidelines.md)
+- [Specification Limit of Vket Cloud](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/WorldMakingGuide/UnityGuidelines.html)
     - Edited content according to Ver5.4 
     - Added restriction on using lights
-- [HEMAnimationConverter](../HEMAnimationConverter/AnimationConverter.md)
+- [HEMAnimationConverter](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/HEMAnimationConverter/AnimationConverter.html)
     - Revised content according to Ver5.4 *English Version WIP
-- [AvatarFile](../WorldMakingGuide/AvatarFile.md)
+- [AvatarFile](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/WorldMakingGuide/AvatarFile.html)
     - Added specifications of AvatarFile
 
 # Deleted Pages

--- a/docs/changelog/changelog-5.4.ja.md
+++ b/docs/changelog/changelog-5.4.ja.md
@@ -1,45 +1,45 @@
 # 追加されたページ
-- [HEOSpot](../HEOComponents/HEOSpot.md)
-- [HEOSpawn](../HEOComponents/HEOSpawn.md)
+- [HEOSpot](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/HEOComponents/HEOSpot.md)
+- [HEOSpawn](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/HEOComponents/HEOSpawn.md)
 - [HEOShadow](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/HEOComponents/HEOShadow.html)
-- [HEOClickGuide](../HEOComponents/HEOClickGuide.md)
-- [SDKがインストール後に立ち上がらない](../troubleshooting/InstallingDeeplink.md)
-- [デバッグコンソール](../debugconsole/debugconsole.md)
-- [デバッグメッセージ](../debugconsole/debugmessage.md)
-- [ブラウザウィンドウが暗転したまま動かない](../troubleshooting/BrowserBlackWindow.md)
-- [オブジェクトをアニメーションさせる](../WorldMakingGuide/PropAnimation.md)
-- [オブジェクトをアニメーションさせる - できない時は](../WorldMakingGuide/PropAnimation_TroubleShooting.md)
-- [バージョンアップ後にComponentがMissingとして表示される](../troubleshooting/MissingComponents.md)
-- [プリセットアバターを追加する](../WorldMakingGuide/PresetAvatar.md)
+- [HEOClickGuide](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/HEOComponents/HEOClickGuide.md)
+- [SDKがインストール後に立ち上がらない](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/troubleshooting/InstallingDeeplink.md)
+- [デバッグコンソール](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/debugconsole/debugconsole.md)
+- [デバッグメッセージ](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/debugconsole/debugmessage.md)
+- [ブラウザウィンドウが暗転したまま動かない](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/troubleshooting/BrowserBlackWindow.md)
+- [オブジェクトをアニメーションさせる](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/WorldMakingGuide/PropAnimation.md)
+- [オブジェクトをアニメーションさせる - できない時は](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/WorldMakingGuide/PropAnimation_TroubleShooting.md)
+- [バージョンアップ後にComponentがMissingとして表示される](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/troubleshooting/MissingComponents.md)
+- [プリセットアバターを追加する](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/WorldMakingGuide/PresetAvatar.md)
 
 # 変更されたページ
-- [はじめに](../index.md) 
-    - [リリースノート](../releasenote/releasenote-5.4.md)と[チェンジログ](../changelog/changelog-5.4.md)についての案内を追加
-- [VketCloudSDKの導入方法](../AboutVketCloudSDK/SetupSDK_external.md)
+- [はじめに](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/index.md) 
+    - [リリースノート](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/releasenote/releasenote-5.4.md)と[チェンジログ](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/changelog/changelog-5.4.md)についての案内を追加
+- [VketCloudSDKの導入方法](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/AboutVketCloudSDK/SetupSDK_external.md)
     - 必須パッケージが自動で入らない場合の案内
     - バージョン切り替えの方法を追記
-- [アバターの使用方法](../AboutVketCloudSDK/SetupAvatar.md)
+- [アバターの使用方法](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/AboutVketCloudSDK/SetupAvatar.md)
     - アバターの使用方法を現行版に更新
-- [テクスチャ圧縮](../heoexporter/he_TextureCompression.md)
+- [テクスチャ圧縮](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/heoexporter/he_TextureCompression.md)
     - 手順をVer5.4基準に更新
-- [HEOVideoTrigger](../HEOComponents/HEOVideoTrigger.md)
+- [HEOVideoTrigger](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/HEOComponents/HEOVideoTrigger.md)
     - 仕様の説明をVer5.4基準に更新
     - 動画音声が距離減衰に対応していない旨の追記
-- [HEOWorldSetting](../HEOComponents/HEOWorldSetting.md)
+- [HEOWorldSetting](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/HEOComponents/HEOWorldSetting.md)
     - 各設定項目をVer5.4基準に更新
     - ゲームパッド / エモート関連の不具合の追記
     - ライトの仕様の追記
     - 動的影の作り方について[HEOShadow](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/HEOComponents/HEOShadow.html)への誘導を追加
-- [HEOAnimation](../HEOComponents/HEOAnimation.md)
+- [HEOAnimation](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/HEOComponents/HEOAnimation.md)
     - HEOAnimationの使い方を追記
-- [HEOAudio](../HEOComponents/HEOAudio.md)
+- [HEOAudio](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/HEOComponents/HEOAudio.md)
     - 仕様の説明をVer5.4基準に更新
-- [Vket Cloudの仕様制限](../WorldMakingGuide/UnityGuidelines.md)
+- [Vket Cloudの仕様制限](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/WorldMakingGuide/UnityGuidelines.md)
     - 仕様制限ページの内容をVer5.4基準に更新
     - ライトの仕様の追記
-- [HEMAnimationConverter](../HEMAnimationConverter/AnimationConverter.md)
+- [HEMAnimationConverter](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/HEMAnimationConverter/AnimationConverter.md)
     - 解説・操作方法をVer5.4基準に更新
-- [AvatarFile](../WorldMakingGuide/AvatarFile.md)
+- [AvatarFile](https://vrhikky.github.io/VketCloudSDK_Documents/5.4/ja/WorldMakingGuide/AvatarFile.md)
     - AvatarFile仕様を追記
 
 # 削除されたページ


### PR DESCRIPTION
マニュアルバージョン間の記述についての差を無くし、メンテナンス性を高めるためにチェンジログのリンクを絶対パスに変更しました。