### PR TITLE
Ver9.11: hs_system_function_gui: hsCanvasSetGUIPos / hsCanvasGetGUIPosの引数を修正

### DIFF
--- a/docs/hs/hs_system_function_gui.en.md
+++ b/docs/hs/hs_system_function_gui.en.md
@@ -19,13 +19,13 @@ Shows the Canvas specified by name with true and hides it with false.
 
 
 ### hsCanvasSetGUIPos
-`bool hsCanvasSetGUIPos(string LayerName, string GUIName, float X, float Y)`
+`bool hsCanvasSetGUIPos(string LayerName, bool IsPortrait, string GUIName, float X, float Y)`
 
 Sets the GUI element's position as the designated value.
 
 
 ### hsCanvasGetGUIPos
-`bool hsCanvasSetGUIPos(string LayerName, string GUIName, ref float X, ref float Y)`
+`bool hsCanvasGetGUIPos(string LayerName, bool IsPortrait, string GUIName, ref float X, ref float Y)`
 
 Gets the GUI element's position value.
 

--- a/docs/hs/hs_system_function_gui.ja.md
+++ b/docs/hs/hs_system_function_gui.ja.md
@@ -21,13 +21,13 @@
 
 
 ### hsCanvasSetGUIPos
-`bool hsCanvasSetGUIPos(string LayerName, string GUIName, float X, float Y)`
+`bool hsCanvasSetGUIPos(string LayerName, bool IsPortrait, string GUIName, float X, float Y)`
 
 指定したGUI要素の座標を変更する。
 
 
 ### hsCanvasGetGUIPos
-`bool hsCanvasSetGUIPos(string LayerName, string GUIName, ref float X, ref float Y)`
+`bool hsCanvasGetGUIPos(string LayerName, bool IsPortrait, string GUIName, ref float X, ref float Y)`
 
 指定したGUI要素の座標を取得する。
 


### PR DESCRIPTION
(cherry picked from commit 506e597547a40c643f751ec11b7d9d6efd66e750) (cherry picked from commit e0b9a306083e41b8c4d140f61bc48d0ab25c898f)