### PR TITLE
mkdocs.yml: VketCloudSDK設定が目次から外れていたので修正

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -244,7 +244,7 @@ nav:
       - Particle Editor - Properties : particleeditor/pe_about_properties.md
     - Export Compressed Texture : SDKTools/ExportCompressedTexture.md
     - VKC Activity Exporter : SDKTools/VKCActivityExporter.md
-    - VketCloudSDK Settings : SDKTools/VketCloudSDK 
+    - VketCloudSDK Settings : SDKTools/VketCloudSDKSettings.md
     - Texture Import Viewer: SDKTools/TextureImportViewer.md
 - World Editing Tips:
   - Quick Menu for adding Vket Cloud objects: WorldEditingTips/QuickMenu.md


### PR DESCRIPTION
## **Type**
Documentation


___

## **Description**
- `mkdocs.yml`ファイルにおいて、ナビゲーションメニューの「VketCloudSDK Settings」のリンクが不完全であったため、正しいMarkdownファイルへのリンクに修正しました。


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mkdocs.yml</strong><dd><code>mkdocs設定ファイルのナビゲーションリンク修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mkdocs.yml
- ナビゲーションメニューにおいて「VketCloudSDK Settings」のリンクが正しく設定されていなかった問題を修正



</details>
    

  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/378/files#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

