### PR TITLE
hs_overview: 見出しのHEOWorldSetting表記を修正

### DIFF
--- a/docs/hs/hs_overview.en.md
+++ b/docs/hs/hs_overview.en.md
@@ -30,7 +30,7 @@ Select "Add Component" > "HEOScript" on the Inspector screen to attach the compo
 In the [HEOScript](../HEOComponents/HEOScript.md) component, select the HeliScript file you want to run. <br>
 By selecting "Select" on the right side of the menu, a list of HeliScripts will appear, so select the HeliScript to be used.
 
-### 3. Enable debug mode in HEOWorldSetting
+### 3. Enable debug mode in VketCloudSettings / BasicSettings
 
 ![hs_overview_4](img/hs_overview_4.jpg)
 

--- a/docs/hs/hs_overview.ja.md
+++ b/docs/hs/hs_overview.ja.md
@@ -30,12 +30,12 @@ Inspector画面にてAdd Component > HEOScriptと選択してコンポーネン�
 [HEOScript](../HEOComponents/HEOScript.md)コンポーネントでは実行したいHeliScriptファイルを選びます。<br>
 メニュー右の「Select」を選択するとHeliScriptの一覧が出現するため、使いたいHeliScriptを選択します。
 
-### 3. HEOWorldSettingにてデバッグモードを有効にする
+### 3. VketCloudSettings / BasicSettingsにてデバッグモードを有効にする
 
 ![hs_overview_4](img/hs_overview_4.jpg)
 
 今回実装するHelloWorldでは、デバッグログにて文字を出力するためにワールドのビルドをデバッグモードに設定する必要があります。<br>
-デバッグモードを使うためにVketCloudSettings[BasicSettings](../VketCloudSettings/BasicSettings.md)の[Debug Mode](../WorldEditingTips/DebugMode.md)を有効にします。
+デバッグモードを使うためにVketCloudSettings / [BasicSettings](../VketCloudSettings/BasicSettings.md)の[Debug Mode](../WorldEditingTips/DebugMode.md)を有効にします。
 
 ### 4. HeliScriptを書く
 


### PR DESCRIPTION
## **Type**
Documentation


___

## **Description**
- 英語と日本語のドキュメントで、デバッグモードの設定パスの表記を「HEOWorldSetting」から「VketCloudSettings / BasicSettings」に更新しました。
- 日本語ドキュメントでは、リンクテキストも新しい設定パスに合わせて修正されています。


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hs_overview.en.md</strong><dd><code>Update English Documentation for Debug Mode Settings Path</code></dd></summary>
<hr>

docs/hs/hs_overview.en.md
<li>Updated the section heading from "HEOWorldSetting" to <br>"VketCloudSettings / BasicSettings" to reflect the correct settings <br>path.<br>


</details>
    

  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/382/files#diff-3f323ac632a020df297208f01f2ba7033f011806d6cfdc21f827847c999f44c2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>hs_overview.ja.md</strong><dd><code>Update Japanese Documentation for Debug Mode Settings Path</code></dd></summary>
<hr>

docs/hs/hs_overview.ja.md
<li>Updated the section heading from "HEOWorldSetting" to <br>"VketCloudSettings / BasicSettings" to reflect the correct settings <br>path.<br> <li> Modified the link text to match the new settings path.<br>


</details>
    

  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/382/files#diff-80d78390c4d57ecf5c39f4eb994f8ba3d2832a7aca66fe4da51ecd5dd32464f7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

