### PR TITLE
BrokerAPI: API使用時はワールドアップロードが必要の旨、追記

### DIFF
--- a/docs/ExternalAPI/BrokerAPI.en.md
+++ b/docs/ExternalAPI/BrokerAPI.en.md
@@ -215,6 +215,11 @@ component BrokerAPI
 }
 ```
 
-3\. Build the world to see if API operates as intended.
+3\. Upload the world data to see if API operates as intended.
+
+!!! warning "Testing BrokerAPI implementations"
+    By feature, BrokerAPI will not function on local **Build And Run** results.<br>
+    To test the function, please upload the world data (in private if needed), and access the uploaded world.<br>
+    For instructions on how to upload the world data, please refer to [World upload](../FirstStep/WorldUpload.md).
 
 ![BrokerAPI_Result](img/BrokerAPI_Result.gif)

--- a/docs/ExternalAPI/BrokerAPI.ja.md
+++ b/docs/ExternalAPI/BrokerAPI.ja.md
@@ -215,6 +215,11 @@ component BrokerAPI
 }
 ```
 
-3\. ワールドをビルドし、結果を確認します。
+3\. ワールドをアップロードし、結果を確認します。
+
+!!! warning "BrokerAPI動作確認時の注意"
+    ローカル環境での**Build And Run**では動作が確認できません。<br>
+    一度非公開の状態などでワールドとしてアップロードして頂いた上、結果の確認をお願いいたします。<br>
+    ワールドのアップロード方法については、[ワールドアップロード](../FirstStep/WorldUpload.md)をご参照ください。
 
 ![BrokerAPI_Result](img/BrokerAPI_Result.gif)


### PR DESCRIPTION
### **User description**
BrokerAPI使用時はワールドアップロードが必要の旨を追記
（日本語ページのみ）


___

### **PR Type**
Documentation


___

### **Description**
- BrokerAPIの使用説明において、ワールドのアップロードが必要であることを明確に記述
- ローカル環境での動作確認が不可能であるため、ワールドをアップロードして結果を確認する手順に変更
- ワールドアップロードの方法についてのリンクを追加し、ユーザーが参照しやすくした


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BrokerAPI.ja.md</strong><dd><code>BrokerAPIのドキュメントにワールドアップロードの必要性を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/ExternalAPI/BrokerAPI.ja.md
<li>「ワールドをビルドし、結果を確認します。」を「ワールドをアップロードし、結果を確認します。」に変更<br> <li> BrokerAPIの使用時にワールドアップロードが必要であることを警告として追加<br> <li> ワールドアップロードの参照リンクを追加<br>


</details>
    

  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/387/files#diff-6de4e4630f65a40599cbdc896f6a082fa3694a0932a026cebddb18e60276ef48">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

