### PR TITLE
hs_overview: HeliScriptについての表現を変更

### DIFF
--- a/docs/changelog/changelog-12.3.en.md
+++ b/docs/changelog/changelog-12.3.en.md
@@ -111,6 +111,7 @@ Added information on HeliScript updates on Ver12.x: *English version WIP
     - Added feature change for Player class functions within constructor
     - Added explanation for Nodes
     - Updated instructions according to Ver12.3
+    - Revised description about HeliScript
   - [Class](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/en/hs/hs_class.html)
     - Added object instantiation / deletion, detecting instants
   - [Components / Callback functions](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/en/hs/hs_component.html)

--- a/docs/changelog/changelog-12.3.ja.md
+++ b/docs/changelog/changelog-12.3.ja.md
@@ -119,6 +119,7 @@ Ver12.xにて追加されたHeliScriptへの変更を追記：
     - コンストラクタにおけるPlayerクラス関数の仕様変更を追記
     - Nodeに関する補足を追記
     - 導入方法をVer12.3準拠に更新
+    - HeliScriptについての表現を変更
   - [クラス](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/hs/hs_class.html)
     - オブジェクトの生成・削除、存在の判定について追記
   - [コンポーネント / コールバック関数](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/hs/hs_component.html)

--- a/docs/hs/hs_overview.en.md
+++ b/docs/hs/hs_overview.en.md
@@ -1,6 +1,6 @@
 # HeliScript - Overview
 
-Vket Cloud allows programming using the engine's own script called HeliScript. <br>
+Vket Cloud allows programming using the engine's own language called HeliScript. <br>
 Using HeliScript, you can implement more complex gimmicks and behaviors compared to using [Actions](../Actions/ActionsOverview.md).
 
 You can learn about the syntax of HeliScript by reading it in order starting from [Built-in types](./hs_var.md). <br>

--- a/docs/hs/hs_overview.ja.md
+++ b/docs/hs/hs_overview.ja.md
@@ -1,6 +1,6 @@
 # HeliScript概要
 
-Vket Cloudでは、HeliScriptというエンジン独自のスクリプトを使用してプログラミングを行うことができます。<br>
+Vket Cloudでは、HeliScriptというエンジン独自の言語を使用してプログラミングを行うことができます。<br>
 HeliScriptを使用すると、[アクション](../Actions/ActionsOverview.md)と比べてより複雑なギミック・挙動を実装できます。
 
 HeliScriptの文法については[基本系](./hs_var.md)から順番に読むことで習得できます。<br>


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- HeliScriptの説明を「スクリプト」から「言語」に変更しました（英語版および日本語版）。
- 変更内容をchangelogに追記しました（英語版および日本語版）。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>changelog-12.3.en.md</strong><dd><code>Update changelog for HeliScript description revision (English)</code></dd></summary>
<hr>

docs/changelog/changelog-12.3.en.md
- Added a note about the revised description of HeliScript.



</details>
    

  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/394/files#diff-2edecac36a9625444684d775e5d5182add66440e669c835093fc7d924193b492">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>changelog-12.3.ja.md</strong><dd><code>Update changelog for HeliScript description revision (Japanese)</code></dd></summary>
<hr>

docs/changelog/changelog-12.3.ja.md
- Added a note about the revised description of HeliScript.



</details>
    

  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/394/files#diff-3f553ed55b0ceaa654790a9fccfd4c87615b6fe9e50bc42adaefaf1d5296649f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>hs_overview.en.md</strong><dd><code>Revise HeliScript description in overview (English)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/hs/hs_overview.en.md
<li>Changed the term <code>script</code> to <code>language</code> for HeliScript description.<br>


</details>
    

  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/394/files#diff-3f323ac632a020df297208f01f2ba7033f011806d6cfdc21f827847c999f44c2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>hs_overview.ja.md</strong><dd><code>Revise HeliScript description in overview (Japanese)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/hs/hs_overview.ja.md
- Changed the term `スクリプト` to `言語` for HeliScript description.



</details>
    

  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/394/files#diff-80d78390c4d57ecf5c39f4eb994f8ba3d2832a7aca66fe4da51ecd5dd32464f7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

