### PR TITLE
12.3のreleasenote及びchangelogにリンクされていたのを更新

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -22,8 +22,8 @@ If you want to try out Vket Cloud worlds, or get an idea on what can be made, ch
     For the manual for stable version, which is supported for an extended period of time, access from [here](https://vrhikky.github.io/VketCloudSDK_Documents/stable/index.html).
 
 !!! info "About Updates"
-    The updates on each VketCloudSDK version can be checked in the [Release Note](releasenote/releasenote-12.3.md).<br>
-    For checking the version updates of this manual, refer to the [Change Log](changelog/changelog-12.3.md).
+    The updates on each VketCloudSDK version can be checked in the [Release Note](releasenote/releasenote-13.4.md).<br>
+    For checking the version updates of this manual, refer to the [Change Log](changelog/changelog-13.4.md).
     If the release note to be read is missing, try changing the version via the page top.
 
 !!! info "Contributions to this manual"

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -22,8 +22,8 @@ SDKを利用するには、`各種アカウントへの登録`と`指定バー�
     また、一定期間のサポートが盛り込まれた安定版のマニュアルは[ここから](https://vrhikky.github.io/VketCloudSDK_Documents/stable/index.html)ご参照ください。
 
 !!! info "更新履歴について"
-    本バージョンのVketCloudSDKの更新情報は[リリースノート](releasenote/releasenote-12.3.md)から確認できます。<br>
-    また、[チェンジログ](changelog/changelog-12.3.md)では本マニュアルにおける更新情報が確認できます。<br>
+    本バージョンのVketCloudSDKの更新情報は[リリースノート](releasenote/releasenote-13.4.md)から確認できます。<br>
+    また、[チェンジログ](changelog/changelog-13.4.md)では本マニュアルにおける更新情報が確認できます。<br>
     もし参照したいバージョンのリリースノートがない際はページトップよりバージョンの切り替えをお試しください。
 
 !!! info "本マニュアルへのコントリビューション"


### PR DESCRIPTION
インデックスより、旧版のreleasenoteとchangelogへのリンクとなっていましたので、更新してみました。