### PR TITLE
HEOPlane: showのデフォルト値を更新

### DIFF
--- a/docs/HEOComponents/HEOPlane.en.md
+++ b/docs/HEOComponents/HEOPlane.en.md
@@ -14,7 +14,7 @@ For details, please refer to the [specification limit](../WorldMakingGuide/Unity
 | World Rotation | Same value as Transform's Rotation value | Set the rotation for displaying text |
 | World Scale | Same value as Transform's Scale value | Set the scale for displaying text |
 | Alpha Blending | false| Lets you use cutout/transparency. |
-| Show | false | Enable if you want the image to appear from the beginning. |
+| Show | true | Enable if you want the image to appear from the beginning. |
 | Z-bias | 0 | Higher z value will make the image show in front of other objects. |
 | Look at Camera | false | Make the image face towards the camera at all times. |
 | Double Side | false | Enable/Disable display on double sides |

--- a/docs/HEOComponents/HEOPlane.ja.md
+++ b/docs/HEOComponents/HEOPlane.ja.md
@@ -20,7 +20,7 @@ Vket Cloudでは以下のフォーマットのテクスチャ画像が使用で�
 | World Rotation | TransformのRotation値と同一 | テキストを表示する角度を指定します |
 | World Scale | TransformのScale値と同一 | テキストを表示する大きさを指定します |
 | Alpha Blending | false | 半透明やカットアウトを使用できます |
-| Show | false | あらかじめ表示したい場合はオンにします |
+| Show | true | あらかじめ表示したい場合はオンにします |
 | Z-Bias | 0 | z値が高いと、ほかのオブジェクトよりも手前に表示されます |
 | Look at Camera | false | カメラ方向に対して常に正面を向くようになります |
 | Double Side | false | 両面表示するか否かを切り替えます |

--- a/docs/changelog/changelog-12.3.en.md
+++ b/docs/changelog/changelog-12.3.en.md
@@ -78,6 +78,8 @@
   - [Texture Compression](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/en/WorldOptimization/TextureCompression.html)
     - Added overview of Texture Import Viewer
 - HEO Components
+  - [HEOPlane](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/en/HEOComponents/HEOPlane.html)
+    - Updated the default value of the component
   - [HEOActivity](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/en/HEOComponents/HEOActivity.html)
     - Added info on Scene Preview and Advanced Settings
   - [HEOAreacollider](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/en/HEOComponents/HEOAreacollider.html)

--- a/docs/changelog/changelog-12.3.ja.md
+++ b/docs/changelog/changelog-12.3.ja.md
@@ -51,7 +51,7 @@
   - [ワールドアップロード](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/FirstStep/WorldUpload.html)
     - World Uploaderの機能追加に伴い追記
 - ワールド制作ガイド
-  - [VketCloudの仕様制限](https://vrhikky.github.io/VketCloudSDK_Documents/latest/WorldMakingGuide/UnityGuidelines.html)
+  - [VketCloudの仕様制限](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/WorldMakingGuide/UnityGuidelines.html)
     - ワールドのトライアングル数およびオーディオ、動画ファイルの仕様制限の追記
     - 使用可能な文字に関する仕様を追記
   - [コライダーの使い方 / Tips](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/WorldMakingGuide/Collider.html)
@@ -93,8 +93,9 @@
     - ワールドにMesh Renderer / Mesh Colliderのみ存在する際のプレイヤーが浮遊する不具合について追記
   - [HEOObject](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/HEOComponents/HEOObject.html)
     - Ver12.3に追加された機能(hrm, glb対応)を追記し、コンポーネント設定解説を更新
-  - [HEOPlane](https://vrhikky.github.io/VketCloudSDK_Documents/latest/HEOComponents/HEOPlane.html)
+  - [HEOPlane](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/HEOComponents/HEOPlane.html)
     - 画像ファイルの仕様制限について追記
+    - コンポーネントのデフォルト値表記を変更
   - [HEOReflectionProbe](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/HEOComponents/HEOReflectionProbe.html)
     - 機能廃止について案内を追記
 - アクションについて


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- `HEOPlane`コンポーネントの`Show`プロパティのデフォルト値を`false`から`true`に変更しました。
- 英語および日本語のドキュメントを更新しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HEOPlane.en.md</strong><dd><code>Update default value of `Show` in HEOPlane documentation (EN)</code></dd></summary>
<hr>

docs/HEOComponents/HEOPlane.en.md

- `Show` default value changed from `false` to `true`.



</details>


  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/418/files#diff-bf55f4a4433c4f069426baa9dd89a83e09c7717763d9239a9bc57bbec370be96">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HEOPlane.ja.md</strong><dd><code>Update default value of `Show` in HEOPlane documentation (JA)</code></dd></summary>
<hr>

docs/HEOComponents/HEOPlane.ja.md

- `Show` default value changed from `false` to `true`.



</details>


  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/418/files#diff-331fd0a16432fa051eab07ae34c3016fdfef85bbdc5c2c7e092739201000357d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

