### PR TITLE
【12.3】hsGetCurrentWorldIdのデータタイプをfloatからstringに変更

### DIFF
--- a/docs/changelog/changelog-12.3.en.md
+++ b/docs/changelog/changelog-12.3.en.md
@@ -141,6 +141,7 @@ Added information on HeliScript updates on Ver12.x: *English version WIP
     - Edited loop examples, break, and continue
   - [Built-in Functions - System](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/en/hs/hs_system_function.html)
     - Added new functions: hsIsMobile and casting functions
+    - Changed data type of hsGetCurrentWorldId from float to string.
   - [Built-in Functions - GUI](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/en/hs/hs_system_function_gui.html)
     - Edited argument of hsCanvasSetGUIPos
   - [Built-in types - Basic Types](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/en/hs/hs_var.html)

--- a/docs/changelog/changelog-12.3.ja.md
+++ b/docs/changelog/changelog-12.3.ja.md
@@ -148,6 +148,7 @@ Ver12.xにて追加されたHeliScriptへの変更を追記：
     - ループの例示、break, continueについて追記
   - [組み込み関数 - システム](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/hs/hs_system_function.html)
     - hsIsMobile, 型変換(キャスト)系関数を追加
+    - hsGetCurrentWorldIdのデータタイプをfloatからstringに変更
   - [組み込み関数 - GUI](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/hs/hs_system_function_gui.html)
     - hsCanvasSetGUIPosの引数を変更
   - [組み込み型](https://vrhikky.github.io/VketCloudSDK_Documents/12.3/hs/hs_var.html)

--- a/docs/hs/hs_system_function.en.md
+++ b/docs/hs/hs_system_function.en.md
@@ -65,7 +65,7 @@ Refer to hsGetDate() for arguments.
 Returns the offset of local timezone and UTC timezone by minutes.
 
 ### hsGetCurrentWorldId
-`float hsGetCurrentWorldId()`
+`string hsGetCurrentWorldId()`
 
 Returns the current world ID.
 

--- a/docs/hs/hs_system_function.ja.md
+++ b/docs/hs/hs_system_function.ja.md
@@ -70,7 +70,7 @@ Vket Cloudがデバッグモードで動作している場合は true を返す�
 システム上の現在のタイムゾーンと、UTCタイムゾーンの差を分単位で返します。
 
 ### hsGetCurrentWorldId
-`float hsGetCurrentWorldId()`
+`string hsGetCurrentWorldId()`
 
 ワールドIDを取得する。
 


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- hsGetCurrentWorldIdのデータタイプをfloatからstringに変更
- 英語版および日本語版のチェンジログにデータタイプ変更を追記
- 英語版および日本語版の関数定義ドキュメントを更新


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>changelog-12.3.en.md</strong><dd><code>英語版チェンジログにデータタイプ変更を追記</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/changelog/changelog-12.3.en.md

- hsGetCurrentWorldIdのデータタイプ変更を追記



</details>


  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/435/files#diff-2edecac36a9625444684d775e5d5182add66440e669c835093fc7d924193b492">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>changelog-12.3.ja.md</strong><dd><code>日本語版チェンジログにデータタイプ変更を追記</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/changelog/changelog-12.3.ja.md

- hsGetCurrentWorldIdのデータタイプ変更を追記



</details>


  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/435/files#diff-3f553ed55b0ceaa654790a9fccfd4c87615b6fe9e50bc42adaefaf1d5296649f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>hs_system_function.en.md</strong><dd><code>英語版ドキュメントの関数定義を更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/hs/hs_system_function.en.md

- hsGetCurrentWorldIdのデータタイプをfloatからstringに変更



</details>


  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/435/files#diff-e0bfae17bab3fd2ae216e601b7e3fce6e5f0536433a230021fcdd7b08841df8b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>hs_system_function.ja.md</strong><dd><code>日本語版ドキュメントの関数定義を更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/hs/hs_system_function.ja.md

- hsGetCurrentWorldIdのデータタイプをfloatからstringに変更



</details>


  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/435/files#diff-b4cd154057302ac80e81fedae86f0586cc1f24211b415829cdff511b10382869">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

