### PR TITLE
ファイルの読み込み順に関する回避策について追記

### DIFF
--- a/docs/WorldMakingGuide/JsUpload.en.md
+++ b/docs/WorldMakingGuide/JsUpload.en.md
@@ -44,7 +44,7 @@ For more information, refer to [Introducing Sample JS Upload](../WorldMakingGuid
 
    ![Set JavaScript](img/JsUpload_3.jpg)
 
-   (Note: When specifying multiple files, the loading order during 'Build and run' follows the order of this setting. However, in the Vket Cloud production environment, the files will be loaded in alphabetical order. To control the loading order, for example, you can prefix file names with a letter like "z" for files that you want to be loaded later.)
+   (Note: When specifying multiple files, the loading order during `Build and run` follows the order of this setting. However, in the Vket Cloud production environment, the files will be loaded in alphabetical order. To control the loading order, for example, you can prefix file names with a letter like "z" for files that you want to be loaded later.)
 
 4. Set the target `Scriptable Object` in the **Base Setting's File Deployment Config**.
 

--- a/docs/WorldMakingGuide/JsUpload.en.md
+++ b/docs/WorldMakingGuide/JsUpload.en.md
@@ -44,6 +44,8 @@ For more information, refer to [Introducing Sample JS Upload](../WorldMakingGuid
 
    ![Set JavaScript](img/JsUpload_3.jpg)
 
+   (Note: When specifying multiple files, the loading order during 'Build and run' follows the order of this setting. However, in the Vket Cloud production environment, the files will be loaded in alphabetical order. To control the loading order, for example, you can prefix file names with a letter like "z" for files that you want to be loaded later.)
+
 4. Set the target `Scriptable Object` in the **Base Setting's File Deployment Config**.
 
    ![Set Scriptable Object](img/JsUpload_4.jpg)

--- a/docs/WorldMakingGuide/JsUpload.ja.md
+++ b/docs/WorldMakingGuide/JsUpload.ja.md
@@ -43,6 +43,8 @@ JSは、一般的にWebブラウザベースのアプリケーションの開発
 
    ![JSのセット](img/JsUpload_3.jpg)
 
+（注意：複数のファイルを指定した場合、現在、`Build and run`時には読み込み順序はこの設定順になりますが、Vket Cloudの本番環境においてはファイル名順にソートされた読み込み順になるため、後半に読み込みたいファイル名は「z」を前置するなどして、読み込み順を制御してください。）
+
 4. **Base SettingのFile Deployment Config**に対象の`Scriptable Object`をセットします。
 
    ![Scriptable Objectのセット](img/JsUpload_4.jpg)


### PR DESCRIPTION
（こちらは現状の回避策的な情報となりますが、個人的に悩んだ部分でしたので、お送りしておきます。対応次第で随時破棄していただければと思います。）

このプルリクエストには、JavaScriptファイルのアップロードに関するドキュメントの更新が含まれており、英語版および日本語版のWorld Making Guideの両方に対する変更が反映されています。これにより、異なるデプロイメントステージにおけるファイルの読み込み順序が明確にされます。

ドキュメントの更新内容:

* [`docs/WorldMakingGuide/JsUpload.en.md`](diffhunk://#diff-88a373c8d19370d540c7aa3c65b3734496aa4dbc64518882de2920343772c3f2R47-R48): `Build and run`フェーズではファイルが指定された順序で読み込まれるが、Vket Cloudの本番環境ではファイルがアルファベット順に読み込まれるという注意書きを追加。また、ファイル名にプレフィックスを付けることで読み込み順序を制御するためのヒントも提供。
* [`docs/WorldMakingGuide/JsUpload.ja.md`](diffhunk://#diff-5c6a762b23196396612e95dc250ca05d17a3ec74e60934c23b0aa167c87cca96R46-R47): `Build and run`時およびVket Cloud本番環境でのファイル読み込み順序についての注意書きを日本語で追加し、順序を制御するためのヒントも含めた内容を追加。