### PR TITLE
ワールド制作ガイド/ロードが完了したら開く扉のページのレイアウトが崩れている

### DIFF
--- a/docs/WorldMakingGuide/DoorOpensAfterLoad.en.md
+++ b/docs/WorldMakingGuide/DoorOpensAfterLoad.en.md
@@ -1,4 +1,4 @@
-!!! info “Information on this page is for VketCloudSDK4.1.4.”
+!!! info "Information on this page is for VketCloudSDK4.1.4."
     The names have been changed since VketCloudSDK13.<br>
     HEOField → VKCItemField <br>
     HEOAreaCollider → VKCItemAreaCollider <br>

--- a/docs/changelog/changelog-14.2.en.md
+++ b/docs/changelog/changelog-14.2.en.md
@@ -1,5 +1,13 @@
 # SDK Manual Change Log - Ver 14.2
 
+## December 12 2024 Update
+
+## December 12 2024 - Edited Pages
+
+- World Making Guide
+    - [Door Opens After Load](https://vrhikky.github.io/VketCloudSDK_Documents/14.2/en/WorldMakingGuide/DoorOpensAfterLoad.html)
+        - Fix layout.
+
 ## November 29 2024 Update
 
 ## November 29 2024 - Edited Pages

--- a/docs/changelog/changelog-14.2.ja.md
+++ b/docs/changelog/changelog-14.2.ja.md
@@ -1,5 +1,13 @@
 # SDK Manual Change Log - Ver 14.2
 
+## 2024年12月02日更新
+
+## 2024年12月02日 - 変更されたページ
+
+- ワールド制作ガイド
+    - [ロードが完了したら開く扉](https://vrhikky.github.io/VketCloudSDK_Documents/14.2/WorldMakingGuide/DoorOpensAfterLoad.html)
+        - レイアウト修正
+
 ## 2024年11月29日更新
 
 ## 2024年11月29日 - 変更されたページ


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- `docs/WorldMakingGuide/DoorOpensAfterLoad.en.md`において、`info`ブロックの引用符スタイルを修正し、Markdownのフォーマットを統一しました。
- `docs/changelog/changelog-14.2.en.md`に2024年12月12日の更新情報を追加し、「Door Opens After Load」のレイアウト修正を記載しました。
- `docs/changelog/changelog-14.2.ja.md`に2024年12月02日の更新情報を追加し、「ロードが完了したら開く扉」のレイアウト修正を記載しました。



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DoorOpensAfterLoad.en.md</strong><dd><code>修正: `info`ブロックの引用符スタイルを統一</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/WorldMakingGuide/DoorOpensAfterLoad.en.md

- 修正: `info`ブロックの引用符を日本語スタイルから英語スタイルに変更。



</details>


  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/561/files#diff-a6132bcefa87ebd006989c771b476db8382f172cc06f950416c64dbc36ba016e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>changelog-14.2.en.md</strong><dd><code>2024年12月12日の更新情報を追加 (英語)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/changelog/changelog-14.2.en.md

<li>2024年12月12日の更新情報を追加。<br> <li> 修正されたページとして「Door Opens After Load」のレイアウト修正を記載。<br>


</details>


  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/561/files#diff-2f3baf40cb41ed78decf8d39000daef3a13e7b63f50de72c9d8a685e1356d6bb">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>changelog-14.2.ja.md</strong><dd><code>2024年12月02日の更新情報を追加 (日本語)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/changelog/changelog-14.2.ja.md

- 2024年12月02日の更新情報を追加。
- 修正されたページとして「ロードが完了したら開く扉」のレイアウト修正を記載。



</details>


  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/561/files#diff-a8f7442620adccd75c20db969e01eb0df04d1ae71c0bdda20f51ce3726dd1a5b">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information