### PR TITLE
[14.5] Hotfix: SetScale項目説明の「このメソッドを呼び出し可能なオブジェクトタイプ」から、VKC Item Fieldを外す

### DIFF
--- a/docs/hs/hs_class_item.en.md
+++ b/docs/hs/hs_class_item.en.md
@@ -241,7 +241,6 @@ Get the scale of Item by Vector3.
 Set the scale of Item by Vector3.
 
 ???+ note "Available object types for this method"
-    - [VKC Item Field](../VKCComponents/VKCItemField.md)
     - [VKC Item Object](../VKCComponents/VKCItemObject.md)
     - [VKC Item Plane](../VKCComponents/VKCItemPlane.md)
     - [VKC Item Text Plane](../VKCComponents/VKCItemTextPlane.md)

--- a/docs/hs/hs_class_item.ja.md
+++ b/docs/hs/hs_class_item.ja.md
@@ -241,7 +241,6 @@ ItemのスケールをVector3として取得します。
 ItemのスケールをVector3で設定します。
 
 ???+ note "このメソッドを呼び出し可能なオブジェクトタイプ"
-    - [VKC Item Field](../VKCComponents/VKCItemField.md)
     - [VKC Item Object](../VKCComponents/VKCItemObject.md)
     - [VKC Item Plane](../VKCComponents/VKCItemPlane.md)
     - [VKC Item Text Plane](../VKCComponents/VKCItemTextPlane.md)


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- `SetScale`メソッドのオブジェクトタイプからVKC Item Field削除

- 英語ドキュメントから該当リスト項目を削除

- 日本語ドキュメントから該当リスト項目を削除


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hs_class_item.en.md</strong><dd><code>Remove VKC Item Field from English doc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/hs/hs_class_item.en.md

- `SetScale`メソッドの利用可能オブジェクトタイプから項目を削除


</details>


  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/696/files#diff-6840ec9070f294c532ad65befd3c0af5707d56bc5914999b32a5be8a5ce1c505">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hs_class_item.ja.md</strong><dd><code>Remove VKC Item Field from Japanese doc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/hs/hs_class_item.ja.md

- `SetScale`メソッドの呼び出し可能オブジェクトから項目を削除


</details>


  </td>
  <td><a href="https://github.com/VRHIKKY/VketCloudSDK_Documents/pull/696/files#diff-f6aecf9ef9a5d9d3b69498c7fbd555a66260b1d37177418542a52d7747e43a08">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>