### PR TITLE
feat: Add Mermaid diagram support to MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -345,7 +345,11 @@ markdown_extensions:
     - codehilite
     - attr_list
     - pymdownx.details
-    - pymdownx.superfences
+    - pymdownx.superfences:
+        custom_fences:
+          - name: mermaid
+            class: mermaid
+            format: !!python/name:pymdownx.superfences.fence_code_format
 
 nav:
 - Introduction: index.md


### PR DESCRIPTION
Added custom fence configuration for Mermaid diagrams in mkdocs.yml. This enables rendering of Mermaid diagrams in code blocks using the
```mermaid syntax.
